### PR TITLE
Sundry updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/keeping-your-actions-up-to-date-with-dependabot
+
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    labels:
+      - "Bot"
+    groups:
+      github-actions:
+        patterns:
+          - '*'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,6 @@ jobs:
         condarc: |
           channels:
             - conda-forge
-            - defaults
         create-args: >-
           python=${{ env.PYTHON_VERSION }}
         environment-name: prod
@@ -51,7 +50,7 @@ jobs:
         python -m coverage xml
 
     - name: Code coverage
-      if: ${{ matrix.PYTHON_VERSION == '3.13' }}
+      if: ${{ matrix.PYTHON_VERSION == '3.14' }}
       uses: codecov/codecov-action@v5
       with:
         files: coverage.xml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ ci:
   autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.2"
+    rev: "v0.14.10"
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [tool.ruff]
 line-length = 179
-target-version = "py39"
+target-version = "py310"
 exclude = [
     "**/*.ipynb",
 ]


### PR DESCRIPTION
- Adds dependabot config to help keep CI things updated.
- Pulls python forward to 3.14 for coverage upload
- Sets a python language target of 3.10, which is the oldest still supported release.